### PR TITLE
Fix kexec issue for kernel with patchlevel greater than 255

### DIFF
--- a/SOURCES/0001-kexec-Remove-the-error-prone-kernel_version-function.patch
+++ b/SOURCES/0001-kexec-Remove-the-error-prone-kernel_version-function.patch
@@ -1,0 +1,189 @@
+From 761d5050ae45d3af69fb456e90308e715edb4ed5 Mon Sep 17 00:00:00 2001
+From: "Eric W. Biederman" <ebiederm@xmission.com>
+Date: Fri, 9 Apr 2021 11:22:51 -0500
+Subject: [PATCH] kexec: Remove the error prone kernel_version function
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+During kexec there are two kernel versions at play.  The version of
+the running kernel and the version of the kernel that will be booted.
+
+On powerpc it appears people have been using the version of the
+running kernel to attempt to detect properties of the kernel to be
+booted which is just wrong.  As the linux kernel version that is being
+detected is a no longer supported kernel just remove that buggy and
+confused code.
+
+On x86_64 the kernel_version is used to compute the starting virtual
+address of the running kernel so a proper core dump may be generated.
+Using the kernel_version stopped working a while ago when the starting
+virtual address  became randomized.
+
+The old code was kept for the case where the kernel was not built with
+randomization support, but there is nothing in reading /proc/kcore
+that won't work to detect the starting virtual address even there.
+In fact /proc/kcore must have the starting virtual address or a
+debugger can not make sense of the running kernel.
+
+So just make computing the starting virtual address on x86_64
+unconditional.  With a hard coded fallback just in case something went
+wrong.
+
+Doing something with kernel_version() has become important as recent
+stable kernels have seen the minor version to > 255.  Just removing
+kernel_version() looks like the best option.
+
+Signed-off-by: "Eric W. Biederman" <ebiederm@xmission.com>
+Signed-off-by: Simon Horman <horms@verge.net.au>
+---
+
+XCP-ng notes:
+Upstream patch: bb6f6f107190f2e6e90a272ea26edb172c37c452
+Backported-by: Thierry Escande <thierry.escande@vates.tech>
+
+ kexec/Makefile                  |  1 -
+ kexec/arch/i386/crashdump-x86.c | 26 ++++++---------
+ kexec/kernel_version.c          | 57 ---------------------------------
+ kexec/kexec.h                   |  4 ---
+ 4 files changed, 9 insertions(+), 79 deletions(-)
+ delete mode 100644 kexec/kernel_version.c
+
+diff --git a/kexec/Makefile b/kexec/Makefile
+index 2b4fb3d..d9e7f69 100644
+--- a/kexec/Makefile
++++ b/kexec/Makefile
+@@ -22,7 +22,6 @@ KEXEC_SRCS_base += kexec/firmware_memmap.c
+ KEXEC_SRCS_base += kexec/crashdump.c
+ KEXEC_SRCS_base += kexec/crashdump-xen.c
+ KEXEC_SRCS_base += kexec/phys_arch.c
+-KEXEC_SRCS_base += kexec/kernel_version.c
+ KEXEC_SRCS_base += kexec/lzma.c
+ KEXEC_SRCS_base += kexec/zlib.c
+ KEXEC_SRCS_base += kexec/kexec-xen.c
+diff --git a/kexec/arch/i386/crashdump-x86.c b/kexec/arch/i386/crashdump-x86.c
+index 69a063a..3a10c83 100644
+--- a/kexec/arch/i386/crashdump-x86.c
++++ b/kexec/arch/i386/crashdump-x86.c
+@@ -60,14 +60,8 @@ static int get_kernel_page_offset(struct kexec_info *UNUSED(info),
+ 	int kv;
+ 
+ 	if (elf_info->machine == EM_X86_64) {
+-		kv = kernel_version();
+-		if (kv < 0)
+-			return -1;
+-
+-		if (kv < KERNEL_VERSION(2, 6, 27))
+-			elf_info->page_offset = X86_64_PAGE_OFFSET_PRE_2_6_27;
+-		else
+-			elf_info->page_offset = X86_64_PAGE_OFFSET;
++		/* get_kernel_vaddr_and_size will override this */
++		elf_info->page_offset = X86_64_PAGE_OFFSET;
+ 	}
+ 	else if (elf_info->machine == EM_386) {
+ 		elf_info->page_offset = X86_PAGE_OFFSET;
+@@ -154,17 +148,15 @@ static int get_kernel_vaddr_and_size(struct kexec_info *UNUSED(info),
+ 
+ 	/* Search for the real PAGE_OFFSET when KASLR memory randomization
+ 	 * is enabled */
+-	if (get_kernel_sym("page_offset_base") != 0) {
+-		for(phdr = ehdr.e_phdr; phdr != end_phdr; phdr++) {
+-			if (phdr->p_type == PT_LOAD) {
+-				vaddr = phdr->p_vaddr & pud_mask;
+-				if (lowest_vaddr == 0 || lowest_vaddr > vaddr)
+-					lowest_vaddr = vaddr;
+-			}
++	for(phdr = ehdr.e_phdr; phdr != end_phdr; phdr++) {
++		if (phdr->p_type == PT_LOAD) {
++			vaddr = phdr->p_vaddr & pud_mask;
++			if (lowest_vaddr == 0 || lowest_vaddr > vaddr)
++				lowest_vaddr = vaddr;
+ 		}
+-		if (lowest_vaddr != 0)
+-			elf_info->page_offset = lowest_vaddr;
+ 	}
++	if (lowest_vaddr != 0)
++		elf_info->page_offset = lowest_vaddr;
+ 
+ 	/* Traverse through the Elf headers and find the region where
+ 	 * _stext symbol is located in. That's where kernel is mapped */
+diff --git a/kexec/kernel_version.c b/kexec/kernel_version.c
+deleted file mode 100644
+index 21fb13a..0000000
+--- a/kexec/kernel_version.c
++++ /dev/null
+@@ -1,57 +0,0 @@
+-#include "kexec.h"
+-#include <errno.h>
+-#include <string.h>
+-#include <sys/utsname.h>
+-#include <string.h>
+-#include <limits.h>
+-#include <stdlib.h>
+-
+-long kernel_version(void)
+-{
+-	struct utsname utsname;
+-	unsigned long major, minor, patch;
+-	char *p;
+-
+-	if (uname(&utsname) < 0) {
+-		fprintf(stderr, "uname failed: %s\n", strerror(errno));
+-		return -1;
+-	}
+-
+-	p = utsname.release;
+-	major = strtoul(p, &p, 10);
+-	if (major == ULONG_MAX) {
+-		fprintf(stderr, "strtoul failed: %s\n", strerror(errno));
+-		return -1;
+-	}
+-
+-	if (*p++ != '.') {
+-		fprintf(stderr, "Unsupported utsname.release: %s\n",
+-			utsname.release);
+-		return -1;
+-	}
+-
+-	minor = strtoul(p, &p, 10);
+-	if (minor == ULONG_MAX) {
+-		fprintf(stderr, "strtoul failed: %s\n", strerror(errno));
+-		return -1;
+-	}
+-
+-	/* There may or may not be a patch level for this kernel */
+-	if (*p++ == '.') {
+-		patch = strtoul(p, &p, 10);
+-		if (patch == ULONG_MAX) {
+-			fprintf(stderr, "strtoul failed: %s\n",strerror(errno));
+-			return -1;
+-		}
+-	} else {
+-		patch = 0;
+-	}
+-
+-	if (major >= 256 || minor >= 256 || patch >= 256) {
+-		fprintf(stderr, "Unsupported utsname.release: %s\n",
+-			utsname.release);
+-		return -1;
+-	}
+-
+-	return KERNEL_VERSION(major, minor, patch);
+-}
+diff --git a/kexec/kexec.h b/kexec/kexec.h
+index 26225d2..c9f6401 100644
+--- a/kexec/kexec.h
++++ b/kexec/kexec.h
+@@ -176,10 +176,6 @@ struct arch_map_entry {
+ extern const struct arch_map_entry arches[];
+ long physical_arch(void);
+ 
+-#define KERNEL_VERSION(major, minor, patch) \
+-	(((major) << 16) | ((minor) << 8) | patch)
+-long kernel_version(void);
+-
+ void usage(void);
+ int get_memory_ranges(struct memory_range **range, int *ranges,
+ 						unsigned long kexec_flags);
+-- 
+2.45.2
+

--- a/SPECS/kexec-tools.spec
+++ b/SPECS/kexec-tools.spec
@@ -8,7 +8,7 @@ Name: kexec-tools
 Summary: kexec/kdump userspace tools
 Epoch: 1
 Version: 2.0.15
-Release: %{?xsrel}%{?dist}
+Release: %{?xsrel}.1%{?dist}
 License: GPL
 
 Source0: kexec-tools-2.0.15.tar.gz
@@ -17,6 +17,9 @@ Source3: kdump.sysconfig
 Source5: kdump
 Source6: kdump.service
 Patch0: 0001-kexec-tools-Remove-duplicated-variable-declarations.patch
+
+# XCP-ng patches
+Patch1000: 0001-kexec-Remove-the-error-prone-kernel_version-function.patch
 
 BuildRequires: gcc
 BuildRequires: xen-dom0-libs-devel, zlib-devel, systemd, autoconf, automake
@@ -91,6 +94,10 @@ exit 0
 %{?_cov_results_package}
 
 %changelog
+* Fri Sep 13 2024 Thierry Escande <thierry.escande@vates.tech> - 2.0.15-20.1
+- Backport patch removing kernel_version(), fixing bug for kernel with
+  patchlevel greater than 255
+
 * Mon Mar 11 2024 Frediano Ziglio <frediano.ziglio@cloud.com> - 2.0.15-20
 - Remove duplicate declaration causing newer toolchain to fail to compile
 


### PR DESCRIPTION
This backports the patch that removes the error prone kernel_version() function. This patch fixes the issue causing kexec to fail with a kernel version that has a patchlevel greater than 255.